### PR TITLE
38 add pwm direction control gpios

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,6 +43,8 @@ pkg_check_modules(GSTAPP REQUIRED gstreamer-app-1.0)
 pkg_check_modules(GSTVIDEO REQUIRED gstreamer-video-1.0)
 pkg_check_modules(GPIOD REQUIRED libgpiod)
 
+find_library(GPIOD_LIBRARY gpiod)
+
 add_executable(${PROJECT_NAME} ${SOURCE})
 
 target_include_directories(${PROJECT_NAME} PRIVATE
@@ -54,6 +56,8 @@ target_include_directories(${PROJECT_NAME} PRIVATE
     ${CMAKE_SOURCE_DIR}/src/Modules
     ${OPENCV_INCLUDE_DIRS}
 )
+
+target_link_libraries(${PROJECT_NAME} PRIVATE ${GPIOD_LIBRARY})
 
 target_link_libraries(${PROJECT_NAME}
     PRIVATE

--- a/src/Devices/Gpio.cpp
+++ b/src/Devices/Gpio.cpp
@@ -1,4 +1,121 @@
 #include "Gpio.hpp"
 #include <fcntl.h>
 
+#include <cstdio>
+
 #include <gpiod.h>
+
+
+namespace Device
+{
+
+const std::unordered_map<int, Gpio::HeaderGpio> Gpio::jetson_orin_nano_gpio_map_lookup = {
+    {7,  {7,  "PAC.06",  0, 144 }},   // GPIO09 (you remapped this)
+    {11, {11, "PH.04",   0, 47  }},   // GPIO17
+    {13, {13, "PH.05",   0, 48  }},   // GPIO27
+    {15, {15, "PN.01",   0, 85  }},   // GPIO22 (can be PWM)
+    {29, {29, "PQ.05",   0, 105 }},   // GPIO05
+    {31, {31, "PQ.06",   0, 106 }},   // GPIO06
+    {32, {32, "PG.06",   0, 41  }},   // GPIO12 (PWM7)
+    {33, {33, "PH.00",   0, 43  }},   // GPIO13 (PWM5)
+    {35, {35, "PI.02",   0, 53  }},   // GPIO19
+    {37, {37, "PY.02",   0, 124 }},   // GPIO26
+};
+
+Gpio::Gpio(int lineOffset, int chipIndex) : Device::DeviceBase(), m_lineOffset(static_cast<unsigned int>(lineOffset)) {
+    char chip_name[20];
+    snprintf(chip_name, sizeof(chip_name), "/dev/gpiochip%d", chipIndex);
+
+    m_chip = gpiod_chip_open(chip_name);
+    if (!m_chip) {
+        return;
+    }
+
+    gpiod_line_settings* settings = gpiod_line_settings_new();
+    if (!settings) {
+        gpiod_chip_close(m_chip);
+        m_chip = nullptr;
+        return;
+    }
+
+    gpiod_line_settings_set_direction(settings, GPIOD_LINE_DIRECTION_OUTPUT);
+    gpiod_line_settings_set_output_value(settings, GPIOD_LINE_VALUE_INACTIVE);
+
+    gpiod_line_config* config = gpiod_line_config_new();
+    if (!config) {
+        gpiod_line_settings_free(settings);
+        gpiod_chip_close(m_chip);
+        m_chip = nullptr;
+        return;
+    }
+
+    if (gpiod_line_config_add_line_settings(config, &m_lineOffset, 1, settings) < 0) {
+        gpiod_line_config_free(config);
+        gpiod_line_settings_free(settings);
+        gpiod_chip_close(m_chip);
+        m_chip = nullptr;
+        return;
+    }
+
+    gpiod_request_config* reqConfig = gpiod_request_config_new();
+    if (!reqConfig) {
+        gpiod_line_config_free(config);
+        gpiod_line_settings_free(settings);
+        gpiod_chip_close(m_chip);
+        m_chip = nullptr;
+        return;
+    }
+
+    gpiod_request_config_set_consumer(reqConfig, "rc_car_gpio");
+
+    m_request = gpiod_chip_request_lines(m_chip, reqConfig, config);
+    gpiod_request_config_free(reqConfig);
+    gpiod_line_config_free(config);
+    gpiod_line_settings_free(settings);
+
+    if (!m_request) {
+        gpiod_chip_close(m_chip);
+        m_chip = nullptr;
+        return;
+    }
+
+    fd = gpiod_line_request_get_fd(m_request);
+}
+
+
+Gpio::~Gpio() {
+    if (m_request) {
+        gpiod_line_request_release(m_request);
+        m_request = nullptr;
+    }
+
+    if (m_chip) {
+        gpiod_chip_close(m_chip);
+        m_chip = nullptr;
+    }
+}
+
+
+Gpio* Gpio::create(int pinNumber) {
+    auto it = jetson_orin_nano_gpio_map_lookup.find(pinNumber);
+    if (it == jetson_orin_nano_gpio_map_lookup.end()) {
+        return nullptr; // Invalid pin number
+    }
+    const HeaderGpio& gpioInfo = it->second;
+    return new Gpio(gpioInfo.line_offset, gpioInfo.gpiochip);
+}
+
+
+int Gpio::gpioWrite(int value) {
+    if (!m_request) {
+        return -1; // Line request not initialized
+    }
+
+    int rc = gpiod_line_request_set_value(
+        m_request,
+        m_lineOffset,
+        value ? GPIOD_LINE_VALUE_ACTIVE : GPIOD_LINE_VALUE_INACTIVE);
+
+    return rc;
+}
+} // namespace Device

--- a/src/Devices/Gpio.hpp
+++ b/src/Devices/Gpio.hpp
@@ -1,15 +1,43 @@
 #pragma once
 
+#include <unordered_map>
 #include "DeviceBase.hpp"
+
+struct gpiod_chip;
+struct gpiod_line_request;
 
 namespace Device
 {
 class Gpio : public Device::DeviceBase {
 public:
-    Gpio(int pinNumber);
+    Gpio(int lineOffset, int chipIndex = 0);
     ~Gpio();
+
+    static Gpio* create(int pinNumber);
+
+    /** 
+     * @brief Write a value to the GPIO pin
+     * 
+     * @param value Value to write (0 or 1)
+     * @return 
+     * 
+     */
+    int gpioWrite(int value);
 private:
-    int fd;
+    struct HeaderGpio
+    {
+        int header_pin;        // Physical header pin number (1–40)
+        const char* soc_name;  // SoC pad name (for debugging)
+        int gpiochip;          // gpiochip index (0 or 1)
+        int line_offset;       // line offset within gpiochip
+    };
+
+    static const std::unordered_map<int, HeaderGpio> jetson_orin_nano_gpio_map_lookup;
+
+    gpiod_chip* m_chip{nullptr};
+    gpiod_line_request* m_request{nullptr};
+    unsigned int m_lineOffset{0};
+    int fd{-1};
 };
 } // namespace Device
 

--- a/src/Modules/RcMotorController.cpp
+++ b/src/Modules/RcMotorController.cpp
@@ -29,6 +29,9 @@ MotorController::MotorController(int moduleID_, std::string name) : Base(moduleI
     } catch (const std::exception& e) {
         logger->log(Logger::LOG_LVL_ERROR, "Failed to initialize PeripheralCtrl and motor control: %s\r\n", e.what());
     }
+
+    // Open GPIO for enabling motor direction
+    m_GpioEnable = Device::Gpio::create(31); // Physical header pin 33, GPIO1_31
 }
 
 MotorController::~MotorController() {
@@ -137,7 +140,10 @@ int MotorController::setMotorSpeed_(int speed) {
     }
 
     if (speed < 0) {
+        m_GpioEnable->gpioWrite(0); // Set direction GPIO high for reverse
         speed *= -2;
+    } else {
+        m_GpioEnable->gpioWrite(1); // Set direction GPIO low for forward
     }
 
     if (speed < 3) {

--- a/src/Modules/RcMotorController.hpp
+++ b/src/Modules/RcMotorController.hpp
@@ -8,6 +8,7 @@
 #include "Devices/Pwm.hpp"
 #include "Devices/DeviceBase.hpp"
 #include "Devices/network_interface/UdpServer.hpp"
+#include "Devices/Gpio.hpp"
 
 
 namespace Modules {
@@ -93,6 +94,12 @@ protected:
      * 
      */
     std::unique_ptr<Device::PeripheralCtrl> peripheralDriver = nullptr;
+
+    /**
+     * @brief GPIO to enable/disable motor controller
+     * 
+     */
+    Device::Gpio* m_GpioEnable = nullptr;
 
     /**
      * @brief Direction control PWM

--- a/version.h
+++ b/version.h
@@ -3,6 +3,6 @@
 
 #define VERSION_MAJOR 1
 #define VERSION_MINOR 2
-#define VERSION_BUILD 2
+#define VERSION_BUILD 3
 
 #endif


### PR DESCRIPTION
This pull request adds support for controlling GPIO pins using the libgpiod library, specifically to enable or disable the motor controller direction on a Jetson Orin Nano. It introduces a new `Gpio` device class, integrates it into the build system, and updates the motor controller module to use this new GPIO functionality for direction control.

**GPIO support and integration:**

* Added new `Gpio` device class (`Gpio.cpp`, `Gpio.hpp`) for abstracting GPIO pin control using libgpiod, including a mapping for Jetson Orin Nano header pins. [[1]](diffhunk://#diff-3d467962040c0f7038f2fb305381a5f054504d6a66622a98b6491e3fd6264ed9R1-R121) [[2]](diffhunk://#diff-52074944a72d607350f0f9e5c5792bb80e0921d47df089306aaf47cea17e8b53R1-R45)
* Updated CMake configuration to find and link against libgpiod, ensuring the project can use GPIO features. [[1]](diffhunk://#diff-148715d6ea0c0ea0a346af3f6bd610d010d490eca35ac6a9b408748f7ca9e3f4R36-R46) [[2]](diffhunk://#diff-148715d6ea0c0ea0a346af3f6bd610d010d490eca35ac6a9b408748f7ca9e3f4R60-R61)

**Motor controller enhancements:**

* Integrated the new `Gpio` class into `MotorController`, adding a member (`m_GpioEnable`) for controlling motor direction via GPIO. [[1]](diffhunk://#diff-b35cfe5f4faac760be4aacb54a401243d93f25254717508b0d3864593820273cR11) [[2]](diffhunk://#diff-b35cfe5f4faac760be4aacb54a401243d93f25254717508b0d3864593820273cR98-R103) [[3]](diffhunk://#diff-3492f890146d5d18b8e9ca532dcfb237a1b03e89f3dc4c94fee53335c47ba13bR32-R34)
* Modified motor speed setting logic to use the GPIO pin for setting the direction (forward or reverse) before applying speed.

**Other:**

* Incremented the build version number to 1.2.3.