### PR TITLE
Fixes:

### DIFF
--- a/src/Modules/AdapterBase.hpp
+++ b/src/Modules/AdapterBase.hpp
@@ -313,16 +313,12 @@ namespace Adapter {
             bool broadcast = false;
             int adapterType = -1;
 
-            int send(const uint8_t* data, size_t length, std::string destIp) {
-                if (sendCallback) {
-                    return sendCallback(destIp, data, length);
-                }
-                return -1;
-            }
-
-            int send(const uint8_t* data, size_t length) {
+            int send(const uint8_t* data, size_t length, std::string destIp="") {
                 if (sendCallbackTcp) {
                     return sendCallbackTcp(data, length);
+                }
+                else if (sendCallback) {
+                    return sendCallback(destIp, data, length);
                 }
                 return -1;
             }

--- a/version.h
+++ b/version.h
@@ -3,6 +3,6 @@
 
 #define VERSION_MAJOR 1
 #define VERSION_MINOR 3
-#define VERSION_BUILD 6
+#define VERSION_BUILD 7
 
 #endif


### PR DESCRIPTION
Adapter method refactoring:

* Unified the `send` method in `AdapterBase` by removing the overload and introducing a default `destIp` parameter, allowing both TCP and non-TCP send callbacks to be handled in a single method.

Version update:

* Incremented the build number in `version.h` from 6 to 7 to reflect the new changes.- Fixed tlm and video transmission not sending